### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-*       @kubawach
-*       @mateuszrzeszutek
+*       @kubawach @mateuszrzeszutek @signalfx/gdi-instrumentation-java


### PR DESCRIPTION
It seems that we should group all codeowners that have the same pattern:

```
# Order is important; the last matching pattern takes the most
# precedence.
```

Also added the instrumentals-java team.