### PR TITLE
GDI spec - configuration module

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This Splunk distribution comes with the following defaults:
 
 - W3C specified Trace Context and Baggage propagation (`tracecontext,baggage`) context propagation
 - OpenTelemetry Protocol (`otlp`) traces exporter
-- no metrics exporter
+- No metrics exporter
 
 This project contains the custom wrapper code in the [wrapper](https://github.com/signalfx/splunk-otel-java-lambda-wrapper/tree/main/wrapper)
 directory and examples in the [examples](https://github.com/signalfx/splunk-otel-java-lambda-wrapper/tree/main/examples) directory.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ template. For more information, see the [example](./examples/splunk-wrapper/READ
    Lambda function code. For more information about available context
    propagators, see the [Propagator settings](https://github.com/open-telemetry/opentelemetry-java/tree/v1.1.0/sdk-extensions/autoconfigure#customizing-the-opentelemetry-sdk)
    for the OpenTelemetry Java.
-6. By default, the Splunk Lambda wrapper uses a `otlp` exporter to send traces to Splunk APM. 
+6. By default, the Splunk Lambda wrapper uses an OpenTelemetry Protocol (`otlp`) exporter to send traces to Splunk APM. 
    
    If you want to use this exporter, set these environment
    variables in your Lambda function code:

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ The current release uses `OpenTelemetry AWS Lambda Instrumentation` version
 
 This Splunk distribution comes with the following defaults:
 
-- `tracecontext,baggage` context propagation
-- `OTLP` traces exporter
+- W3C specified Trace Context and Baggage propagation (`tracecontext,baggage`) context propagation
+- OpenTelemetry Protocol (`otlp`) traces exporter
 - no metrics exporter
 
 This project contains the custom wrapper code in the [wrapper](https://github.com/signalfx/splunk-otel-java-lambda-wrapper/tree/main/wrapper)
@@ -125,7 +125,7 @@ template. For more information, see the [example](./examples/splunk-wrapper/READ
    For more information about setting environment variables in the AWS console,
    see [Using AWS Lambda environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
    on the AWS website.
-5. By default, the Splunk Lambda wrapper uses `tracecontext,baggage` context propagation. 
+5. By default, the Splunk Lambda wrapper uses W3C specified Trace Context and Baggage (`tracecontext,baggage`) context propagation. 
     
    If you want to change this, set the `OTEL_PROPAGATORS` environment variable in your
    Lambda function code. For more information about available context

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ The current release uses `OpenTelemetry AWS Lambda Instrumentation` version
 
 This Splunk distribution comes with the following defaults:
 
-- [B3 context propagation](https://github.com/openzipkin/b3-propagation).
-- [Jaeger-Thrift exporter](https://www.jaegertracing.io).
+- `tracecontext,baggage` context propagation
+- `OTLP` traces exporter
+- no metrics exporter
 
 This project contains the custom wrapper code in the [wrapper](https://github.com/signalfx/splunk-otel-java-lambda-wrapper/tree/main/wrapper)
 directory and examples in the [examples](https://github.com/signalfx/splunk-otel-java-lambda-wrapper/tree/main/examples) directory.
@@ -124,20 +125,19 @@ template. For more information, see the [example](./examples/splunk-wrapper/READ
    For more information about setting environment variables in the AWS console,
    see [Using AWS Lambda environment variables](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars.html)
    on the AWS website.
-5. By default, the Splunk Lambda wrapper uses B3 context propagation. 
+5. By default, the Splunk Lambda wrapper uses `tracecontext,baggage` context propagation. 
     
-    If you want to change this, set the `OTEL_PROPAGATORS` environment variable in your
+   If you want to change this, set the `OTEL_PROPAGATORS` environment variable in your
    Lambda function code. For more information about available context
    propagators, see the [Propagator settings](https://github.com/open-telemetry/opentelemetry-java/tree/v1.1.0/sdk-extensions/autoconfigure#customizing-the-opentelemetry-sdk)
    for the OpenTelemetry Java.
-6. By default, the Splunk Lambda wrapper uses a `jaeger-thrift-splunk` exporter to send
-   traces to Splunk APM. 
+6. By default, the Splunk Lambda wrapper uses a `otlp` exporter to send traces to Splunk APM. 
    
    If you want to use this exporter, set these environment
    variables in your Lambda function code:
    ```
-   OTEL_EXPORTER_JAEGER_ENDPOINT="http://yourEndpoint:9080/v1/trace"
-   SIGNALFX_AUTH_TOKEN="orgAccessToken"
+   OTEL_EXPORTER_OTLP_ENDPOINT="http://yourEndpoint:4317"
+   SPLUNK_AUTH_TOKEN="orgAccessToken"
    ```
    Also, you can set span flush wait timeout, that is max time the function will wait for the spans to be ingested by the Splunk APM. Default is 1 second. 
    Timeout is controlled with a following property (value in milliseconds):
@@ -147,8 +147,15 @@ template. For more information, see the [example](./examples/splunk-wrapper/READ
    
    If you want to use a different exporter, set the `OTEL_TRACES_EXPORTER`
    environment variable. Other exporters have their own configuration settings.
-   For more information, see the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java/tree/v1.1.0/sdk-extensions/autoconfigure#customizing-the-opentelemetry-sdk)
-   on GitHub.
+   For more information, see the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java/tree/v1.1.0/sdk-extensions/autoconfigure#customizing-the-opentelemetry-sdk) on GitHub.
+   
+   Splunk provides also token-authenticated `jaeger-thrift-splunk` exporter for customers that need to use that specific protocol. In order to use it, please set (example endpoint value for SmartAgent):
+   ```
+    OTEL_TRACES_EXPORTER=jaeger-thrift-splunk
+    OTEL_EXPORTER_JAEGER_ENDPOINT=http://127.0.0.1:9080/v1/trace
+    SPLUNK_AUTH_TOKEN="orgAccessToken"
+   ``` 
+   
 7. Set the environment in Splunk APM for the service with the
    `OTEL_RESOURCE_ATTRIBUTES` environment variable:
    ```

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ template. For more information, see the [example](./examples/splunk-wrapper/READ
    Lambda function code. For more information about available context
    propagators, see the [Propagator settings](https://github.com/open-telemetry/opentelemetry-java/tree/v1.1.0/sdk-extensions/autoconfigure#customizing-the-opentelemetry-sdk)
    for the OpenTelemetry Java.
-6. By default, the Splunk Lambda wrapper uses an OpenTelemetry Protocol (`otlp`) exporter to send traces to Splunk APM. 
+6. By default, the Splunk Lambda wrapper uses the OpenTelemetry Protocol (`otlp`) exporter to send traces to Splunk APM. 
    
    If you want to use this exporter, set these environment
    variables in your Lambda function code:

--- a/wrapper/src/main/java/com/splunk/support/lambda/configuration/Config.java
+++ b/wrapper/src/main/java/com/splunk/support/lambda/configuration/Config.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.support.lambda.configuration;
+
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class Config {
+
+  private static final Logger log = LoggerFactory.getLogger(Config.class);
+
+  static void setDefaultValue(String name, String value) {
+    if (!isConfigured(name)) {
+      log.info("Setting default value. name={}, value={}", name, value);
+      System.setProperty(name, value);
+    }
+  }
+
+  private static boolean isConfigured(String name) {
+    return (System.getProperty(name) != null || System.getenv(toEnvVarName(name)) != null);
+  }
+
+  static String getValueOrDefault(String name) {
+
+    String result = System.getProperty(name);
+    if (result == null) {
+      String envValue = System.getenv(toEnvVarName(name));
+      result = (envValue == null ? "" : envValue);
+    }
+    return result;
+  }
+
+  private static final Pattern ENV_REPLACEMENT = Pattern.compile("[^a-zA-Z0-9_]");
+
+  private static String toEnvVarName(String propertyName) {
+    return ENV_REPLACEMENT.matcher(propertyName.toUpperCase()).replaceAll("_");
+  }
+}

--- a/wrapper/src/main/java/com/splunk/support/lambda/configuration/ConfigValidator.java
+++ b/wrapper/src/main/java/com/splunk/support/lambda/configuration/ConfigValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.support.lambda.configuration;
+
+import static com.splunk.support.lambda.configuration.Config.getValueOrDefault;
+
+import io.opentelemetry.semconv.resource.attributes.ResourceAttributes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ConfigValidator {
+
+  private static final Logger log = LoggerFactory.getLogger(ConfigValidator.class);
+
+  static void validate() {
+    String resourceAttributes = getValueOrDefault("otel.resource.attributes");
+    if (!resourceAttributes.contains(ResourceAttributes.SERVICE_NAME.getKey())) {
+      log.warn(
+          "Resource attribute 'service.name' is not set: your service is unnamed and will be difficult to identify."
+              + " Please Set your service name using the 'OTEL_RESOURCE_ATTRIBUTES' environment variable"
+              + " or the 'otel.resource.attributes' system property."
+              + " E.g. 'export OTEL_RESOURCE_ATTRIBUTES=\"service.name=<YOUR_SERVICE_NAME_HERE>\"'");
+    }
+  }
+}

--- a/wrapper/src/main/java/com/splunk/support/lambda/configuration/DefaultConfiguration.java
+++ b/wrapper/src/main/java/com/splunk/support/lambda/configuration/DefaultConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.splunk.support.lambda.configuration;
+
+import static com.splunk.support.lambda.configuration.Config.setDefaultValue;
+import static com.splunk.support.lambda.configuration.JaegerThriftSpanExporterFactory.OTEL_EXPORTER_JAEGER_ENDPOINT;
+
+public class DefaultConfiguration {
+
+  private static final String DISABLED_RESOURCE_PROVIDERS =
+      String.join(
+          ",",
+          "io.opentelemetry.sdk.extension.resources.OsResourceProvider",
+          "io.opentelemetry.sdk.extension.resources.ProcessResourceProvider",
+          "io.opentelemetry.sdk.extension.aws.resource.BeanstalkResourceProvider",
+          "io.opentelemetry.sdk.extension.aws.resource.Ec2ResourceProvider",
+          "io.opentelemetry.sdk.extension.aws.resource.EcsResourceProvider",
+          "io.opentelemetry.sdk.extension.aws.resource.EksResourceProvider");
+
+  static void applyDefaults() {
+
+    // by default no metrics are exported
+    setDefaultValue("otel.metrics.exporter", "none");
+
+    setDefaultValue("otel.propagators", "tracecontext,baggage");
+    setDefaultValue("otel.traces.exporter", "otlp");
+    // http://localhost:9080/v1/trace is the default endpoint for SmartAgent
+    // http://localhost:14268/api/traces is the default endpoint for otel-collector
+    // jaeger-thrift defaults - if configured by the customer
+    setDefaultValue(OTEL_EXPORTER_JAEGER_ENDPOINT, "http://127.0.0.1:9080/v1/trace");
+
+    // sample ALL
+    setDefaultValue("otel.traces.sampler", "always_on");
+
+    // disable non-lambda resource providers
+    setDefaultValue("otel.java.disabled.resource.providers", DISABLED_RESOURCE_PROVIDERS);
+  }
+}

--- a/wrapper/src/main/java/com/splunk/support/lambda/configuration/JaegerThriftSpanExporterFactory.java
+++ b/wrapper/src/main/java/com/splunk/support/lambda/configuration/JaegerThriftSpanExporterFactory.java
@@ -16,6 +16,8 @@
 
 package com.splunk.support.lambda.configuration;
 
+import static com.splunk.support.lambda.configuration.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
+
 import com.google.auto.service.AutoService;
 import io.jaegertracing.thrift.internal.senders.HttpSender;
 import io.opentelemetry.exporter.jaeger.thrift.JaegerThriftSpanExporter;
@@ -31,7 +33,6 @@ import org.slf4j.LoggerFactory;
 public class JaegerThriftSpanExporterFactory implements ConfigurableSpanExporterProvider {
   private static final Logger log = LoggerFactory.getLogger(JaegerThriftSpanExporterFactory.class);
 
-  static final String SIGNALFX_AUTH_TOKEN = "signalfx.auth.token";
   public static final String OTEL_EXPORTER_JAEGER_ENDPOINT = "otel.exporter.jaeger.endpoint";
 
   @Override
@@ -39,7 +40,7 @@ public class JaegerThriftSpanExporterFactory implements ConfigurableSpanExporter
     JaegerThriftSpanExporterBuilder builder = JaegerThriftSpanExporter.builder();
 
     String endpoint = config.getString(OTEL_EXPORTER_JAEGER_ENDPOINT);
-    String token = config.getString(SIGNALFX_AUTH_TOKEN);
+    String token = config.getString(SPLUNK_ACCESS_TOKEN);
     if (token != null && !token.isEmpty()) {
       log.debug("Using authenticated jaeger-thrift exporter");
       builder.setThriftSender(


### PR DESCRIPTION
Configuration module. Changes:

- splunk access token property rename
- default propagator and exporter
- splunk access token for OTLP exporter
- service name property missing warning
- optional `jaeger-thrift-splunk` that defaults to `http://127.0.0.1:9080/v1/trace`
