### PR TITLE
setting correct next release value

### DIFF
--- a/.github/release.properties
+++ b/.github/release.properties
@@ -1,1 +1,1 @@
-current.release=1.0.0
+current.release=0.0.4

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -11,7 +11,7 @@ ext {
             opentelemetry: '1.1.0',
             opentelemetryalpha: '1.1.0-alpha',
             instrumentation: '1.1.0-alpha',
-            wrapper: '1.1.0-SNAPSHOT'
+            wrapper: '0.0.5-SNAPSHOT'
     ]
 }
 

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.signalfx.public</groupId>
     <artifactId>otel-java-lambda-wrapper</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>0.0.5-SNAPSHOT</version>
     <name>Splunk OTEL-based Lambda Wrapper</name>
     <description>
         Splunk release of the OpenTelemetry Java Lambda Wrapper


### PR DESCRIPTION
As the repo is going GA soon, next release version should be 0.0.5, not 1.1.0