### PR TITLE
Release 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.0.6] - 01.10.2021
+
+### Bugfixes
+- Fixed issue with missing `opentelemetry-extension-aws` module, preventing trace propagation from XRay.
+
+### Enhancements
+- Set `jaeger-thrift-splunk` endpoint URL default value, enabling usage of the library even with generic wrappers. 
+
 ## [0.0.5] - 13.08.2021
 
 ### General

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -11,7 +11,7 @@ ext {
             opentelemetry: '1.1.0',
             opentelemetryalpha: '1.1.0-alpha',
             instrumentation: '1.1.0-alpha',
-            wrapper: '0.1.0-SNAPSHOT'
+            wrapper: '0.0.6-SNAPSHOT'
     ]
 }
 

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -6,7 +6,7 @@
     <groupId>com.signalfx.public</groupId>
     <artifactId>otel-java-lambda-wrapper</artifactId>
     <packaging>jar</packaging>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.0.6-SNAPSHOT</version>
     <name>Splunk OTEL-based Lambda Wrapper</name>
     <description>
         Splunk release of the OpenTelemetry Java Lambda Wrapper
@@ -256,6 +256,12 @@
             <artifactId>opentelemetry-sdk-extension-resources</artifactId>
             <version>${otel.version}</version>
         </dependency>
+        <!-- AWS resource providers -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk-extension-aws</artifactId>
+            <version>${otel.version}</version>
+        </dependency>
         <!-- AUTO SERVICE - for SDK -->
         <dependency>
             <groupId>com.google.auto.service</groupId>
@@ -305,7 +311,7 @@
         </dependency>
         <dependency>
             <groupId>io.opentelemetry</groupId>
-            <artifactId>opentelemetry-sdk-extension-aws</artifactId>
+            <artifactId>opentelemetry-extension-aws</artifactId>
             <version>${otel.version}</version>
         </dependency>
 

--- a/wrapper/src/main/java/com/splunk/support/lambda/configuration/DefaultConfiguration.java
+++ b/wrapper/src/main/java/com/splunk/support/lambda/configuration/DefaultConfiguration.java
@@ -17,7 +17,6 @@
 package com.splunk.support.lambda.configuration;
 
 import static com.splunk.support.lambda.configuration.Config.setDefaultValue;
-import static com.splunk.support.lambda.configuration.JaegerThriftSpanExporterFactory.OTEL_EXPORTER_JAEGER_ENDPOINT;
 
 public class DefaultConfiguration {
 
@@ -38,10 +37,6 @@ public class DefaultConfiguration {
 
     setDefaultValue("otel.propagators", "tracecontext,baggage");
     setDefaultValue("otel.traces.exporter", "otlp");
-    // http://localhost:9080/v1/trace is the default endpoint for SmartAgent
-    // http://localhost:14268/api/traces is the default endpoint for otel-collector
-    // jaeger-thrift defaults - if configured by the customer
-    setDefaultValue(OTEL_EXPORTER_JAEGER_ENDPOINT, "http://127.0.0.1:9080/v1/trace");
 
     // sample ALL
     setDefaultValue("otel.traces.sampler", "always_on");

--- a/wrapper/src/main/java/com/splunk/support/lambda/configuration/JaegerThriftSpanExporterFactory.java
+++ b/wrapper/src/main/java/com/splunk/support/lambda/configuration/JaegerThriftSpanExporterFactory.java
@@ -49,8 +49,8 @@ public class JaegerThriftSpanExporterFactory implements ConfigurableSpanExporter
     if (isNullOrEmpty(endpoint)) {
       endpoint = OTEL_EXPORTER_JAEGER_ENDPOINT_DEFAULT;
       log.debug(
-          "Using default value for OTEL_EXPORTER_JAEGER_ENDPOINT="
-              + OTEL_EXPORTER_JAEGER_ENDPOINT_DEFAULT);
+          "Using default value for OTEL_EXPORTER_JAEGER_ENDPOINT={}",
+          OTEL_EXPORTER_JAEGER_ENDPOINT_DEFAULT);
     }
     String token = config.getString(SPLUNK_ACCESS_TOKEN);
     if (isNullOrEmpty(token)) {

--- a/wrapper/src/main/java/com/splunk/support/lambda/configuration/JaegerThriftSpanExporterFactory.java
+++ b/wrapper/src/main/java/com/splunk/support/lambda/configuration/JaegerThriftSpanExporterFactory.java
@@ -17,6 +17,7 @@
 package com.splunk.support.lambda.configuration;
 
 import static com.splunk.support.lambda.configuration.SplunkConfiguration.SPLUNK_ACCESS_TOKEN;
+import static io.opentelemetry.api.internal.StringUtils.isNullOrEmpty;
 
 import com.google.auto.service.AutoService;
 import io.jaegertracing.thrift.internal.senders.HttpSender;
@@ -35,13 +36,27 @@ public class JaegerThriftSpanExporterFactory implements ConfigurableSpanExporter
 
   public static final String OTEL_EXPORTER_JAEGER_ENDPOINT = "otel.exporter.jaeger.endpoint";
 
+  // http://localhost:9080/v1/trace is the default endpoint for SmartAgent
+  // http://localhost:14268/api/traces is the default endpoint for otel-collector
+  private static final String OTEL_EXPORTER_JAEGER_ENDPOINT_DEFAULT =
+      "http://127.0.0.1:9080/v1/trace";
+
   @Override
   public SpanExporter createExporter(ConfigProperties config) {
     JaegerThriftSpanExporterBuilder builder = JaegerThriftSpanExporter.builder();
 
     String endpoint = config.getString(OTEL_EXPORTER_JAEGER_ENDPOINT);
+    if (isNullOrEmpty(endpoint)) {
+      endpoint = OTEL_EXPORTER_JAEGER_ENDPOINT_DEFAULT;
+      log.debug(
+          "Using default value for OTEL_EXPORTER_JAEGER_ENDPOINT="
+              + OTEL_EXPORTER_JAEGER_ENDPOINT_DEFAULT);
+    }
     String token = config.getString(SPLUNK_ACCESS_TOKEN);
-    if (token != null && !token.isEmpty()) {
+    if (isNullOrEmpty(token)) {
+      log.debug("Using jaeger-thrift exporter without authentication");
+      builder.setEndpoint(endpoint);
+    } else {
       log.debug("Using authenticated jaeger-thrift exporter");
       builder.setThriftSender(
           new HttpSender.Builder(endpoint)
@@ -50,11 +65,7 @@ public class JaegerThriftSpanExporterFactory implements ConfigurableSpanExporter
                       .addInterceptor(new AuthTokenInterceptor(token))
                       .build())
               .build());
-    } else {
-      log.debug("Using jaeger-thrift exporter without authentication");
-      builder.setEndpoint(endpoint);
     }
-
     return builder.build();
   }
 


### PR DESCRIPTION
- Fixed issue with missing `opentelemetry-extension-aws` module, preventing trace propagation from XRay.
- Set `jaeger-thrift-splunk` endpoint URL default value, enabling usage of the library even with generic wrappers. 